### PR TITLE
Fix (emacs-lisp.eld): Fix typo

### DIFF
--- a/templates/emacs-lisp.eld
+++ b/templates/emacs-lisp.eld
@@ -29,5 +29,5 @@ emacs-lisp-mode
         "(advice-add #'" (p "fun") " " (p ":around") " #'" (s name) ")")
 (provide "(provide '" (file-name-base (or (buffer-file-name) (buffer-name))) ")" n
          ";;; " (file-name-nondirectory (or (buffer-file-name) (buffer-name))) " ends here" n)
-(log "(message \"LOG %s %S: " (s sexp)
+(log "(message \"LOG %s " (s sexp) ": %S"
      "\" (format-time-string \"%X\") " sexp ")")


### PR DESCRIPTION
The variable should go first and the value second.