### PR TITLE
Add readonly-tanlge snippet to org-mode

### DIFF
--- a/templates/org.eld
+++ b/templates/org.eld
@@ -28,3 +28,4 @@ org-mode
 (elisp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
 (inlsrc "src_" p "{" q "}")
 (title "#+title: " p n "#+author: " p n "#+language: " p n n)
+(readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)


### PR DESCRIPTION
This line can be used on `org-block-begin-line` so the file tangled will be read-only.

This can also be used as header property.

Useful for `org-babel` users.