### PR TITLE
Add snippets to org-mode

### DIFF
--- a/templates/org.eld
+++ b/templates/org.eld
@@ -28,3 +28,4 @@ org-mode
 (elisp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
 (inlsrc "src_" p "{" q "}")
 (title "#+title: " p n "#+author: " p n "#+language: " p n n)
+(readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)

--- a/templates/org.eld
+++ b/templates/org.eld
@@ -11,7 +11,7 @@ org-mode
 (elsp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
 (readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
 (oxhugo ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: " (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
-(readmecollapse  "*** " p n "#+begin_html" n "<details>" n "<summary> " (p "heading")  " </summary>" n "#+end_html" n (p "link or any comments") n n "#+begin_html" n "</details>" n "#+end_html" n n)
+(readmecollapse  "*** " (p "Heading") n "#+begin_html" n "<details>" n "<summary> " (p "sub-heading")  " </summary>" n "#+end_html" n (p "link or any comments") n n "#+begin_html" n "</details>" n "#+end_html" n n)
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
 (caption "#+caption: ")

--- a/templates/org.eld
+++ b/templates/org.eld
@@ -9,6 +9,9 @@ org-mode
 (src "#+begin_src " p n> r> n> "#+end_src" :post (org-edit-src-code))
 (rst "#+begin_src restclient" p n> r> n> "#+end_src" :post (org-edit-src-code))
 (elsp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
+(readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
+(oxhugo ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: " (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
+(readmecollapse  "*** " p n "#+begin_html" n "<details>" n "<summary> " (p "heading")  " </summary>" n "#+end_html" n (p "link or any comments") n n "#+begin_html" n "</details>" n "#+end_html" n n)
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
 (caption "#+caption: ")
@@ -28,4 +31,3 @@ org-mode
 (elisp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
 (inlsrc "src_" p "{" q "}")
 (title "#+title: " p n "#+author: " p n "#+language: " p n n)
-(readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)


### PR DESCRIPTION
1. temp-`readonly` - This line can be added to `org-block-begin-line` or header property to make the tangled file as read-only.
    - Useful for `org-babel` users.


2. temp-`oxhugo` - Helpful for `ox-hugo` users to write blogs/posts in single org file, used as header property.

3. temp-`readmecollapse` - Make collapsable heading in git readme(.)org files. Useful for inserting images, by default it will be collapsed in git readme.