### PR TITLE
Added markdown & nix mode

### DIFF
--- a/templates/markdown.eld
+++ b/templates/markdown.eld
@@ -1,0 +1,18 @@
+markdown-mode
+
+(gitcollapse "## " (p "Heading") n n "<details>" n n
+             "<summary>" (p "Sub Heading")  "</summary>" n n
+             (r "Insert Link or comments") n n "</details>")
+(bolditalics "***" p "***")
+(srcblock (call-interactively #'markdown-insert-gfm-code-block))
+(src "'" p "'")
+(unorderlist "- " (p "First") n> "- " (p "Second") n> "- " (p "Third"))
+(orderlist "1. " (p "First") n> "2. " (p "Second") n> "3. " (p "Third"))
+(insertimage (call-interactively #'markdown-insert-image))
+(insertlink (call-interactively #'markdown-insert-link))
+(hugotitle "+++" n "title = " (p "title") n "date = " (format-time-string "%Y-%m-%d") n "tags = [ " (p "tag1, tag2 ") "]" n "draft = false" n "+++")
+(h1 "# " p " #")
+(h2 "## " p " ##")
+(h3 "### " p " ###")
+(h4 "#### " p " ####")
+(inserttable (call-interactively #'markdown-insert-table))

--- a/templates/nix.eld
+++ b/templates/nix.eld
@@ -1,0 +1,12 @@
+nix-mode
+
+(buildphase > "buildPhase= ''" n (p "Build Instructions") n " '';")
+(checkPhase > "checkPhase= ''" n (p "") n " '';")
+(configurephase > "configurePhase= ''" n (p "") n " '';")
+(fixupphase > "fixupPhase= ''" n (p "") n " '';")
+(distphase > "distPhase= ''" n (p "") n " '';")
+(patchphase > "patchPhase= ''" n (p "") n " '';")
+(unpackphase > "unpackPhase= ''" n (p "") n " '';")
+(installCheckPhasephase > "installCheckPhasePhase= ''" n (p "") n " '';")
+(installphase > "installphase= ''" n p " mkdir -p $out/bin" n> "for f in $(find . -executable -type f);" n> "do" n> "cp $f $out/bin" n> "done}" n> " '';")
+

--- a/templates/org.eld
+++ b/templates/org.eld
@@ -11,7 +11,7 @@ org-mode
 (elsp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
 (readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
 (oxhugo ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: " (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
-(readmecollapse  "*** " (p "Heading") n "#+begin_html" n "<details>" n "<summary> " (p "sub-heading")  " </summary>" n "#+end_html" n (p "link or any comments") n n "#+begin_html" n "</details>" n "#+end_html" n n)
+(readmecollapse  "*** " (p "Heading") n "#+begin_html" n "<details>" n "<summary> " (p "sub-heading")  " </summary>" n "#+end_html" n (r> "link or any comments") n n "#+begin_html" n "</details>" n "#+end_html" n n)
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
 (caption "#+caption: ")


### PR DESCRIPTION
1. There is simple fix on org.eld to use `r` instead of `p` so can include marked text.

2. Markdown-mode has few snips, some make `(call-interactively #'markdown-mode-insert-*` to make it simple.

3. Nix also has simple one's. Need to understand ~tempel~ package more so can extend it more.

Over time will try to extend the snippets.

