### PR TITLE
Simplified readmecollapse

### DIFF
--- a/templates/org.eld
+++ b/templates/org.eld
@@ -11,7 +11,7 @@ org-mode
 (elsp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
 (readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
 (oxhugo ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: " (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
-(readmecollapse  "*** " (p "Heading") n "#+begin_html" n "<details>" n "<summary> " (p "sub-heading")  " </summary>" n "#+end_html" n (r> "link or any comments") n n "#+begin_html" n "</details>" n "#+end_html" n n)
+(readmecollapse  "*** " (p "Heading") n "#+HTML: <details> <summary> " (p "sub-heading")  " </summary>" n (r> "link or any comments") n n "#+HTML: </details>" n)
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
 (caption "#+caption: ")


### PR DESCRIPTION
Use #+HTML: tags instead of a html block (in org.eld). This can make it one-liner.

The content works the same as before.
Eg : [d-bin](https://github.com/idlip/d-bin)