### PR TITLE
Add type hint ignore snippet

### DIFF
--- a/templates/python-base.eld
+++ b/templates/python-base.eld
@@ -2,4 +2,5 @@ python-base-mode
 
 (for "for " p " in " p ":" n> q)
 (pu "import pudb; pu.db" q)
+(ig "# type: ignore" q)
 


### PR DESCRIPTION
Hi,

This PR adds a snippet that I find very useful when working with Python and the type checker as described here:

https://mypy.readthedocs.io/en/stable/common_issues.html#spurious-errors-and-locally-silencing-the-checker