### PR TITLE
Add set_trace snippet

### DIFF
--- a/templates/python-base.eld
+++ b/templates/python-base.eld
@@ -1,6 +1,6 @@
 python-base-mode
 
 (for "for " p " in " p ":" n> q)
-(pu "import pudb; pu.db" q)
+(tr "import " p "; " p ".set_trace()" q)
 (ig "# type: ignore" q)
 


### PR DESCRIPTION
This PR removes the previous snippet bound to `pu` that I added. and introduces a new snippet bound to `tr` which is short for trace as in `set_trace()`. I think this is a better use of tempel and allows one to modularize the snippet over pdb, ipdb, and pudb.

For example, with pdb you can do the following:

```python
import pdb; pdb.set_trace()
```

with ipdb:

```python
import ipdb; ipdb.set_trace()
```

with pudb

```python
import pudb; pudb.set_trace()
```