### PR TITLE
Nixpkgs template

### DIFF
--- a/templates/nix.eld
+++ b/templates/nix.eld
@@ -10,3 +10,16 @@ nix-mode
 (installCheckPhasephase > "installCheckPhasePhase= ''" n (p "") n " '';")
 (installphase > "installphase= ''" n p " mkdir -p $out/bin" n> "for f in $(find . -executable -type f);" n> "do" n> "cp $f $out/bin" n> "done}" n> " '';")
 
+(gitpackage "{ lib" n ", stdenv" n ", fetchFromGitHub" n ", " (p "inputs") n ", " (p "inputs") n "}:" n n>
+            "stdenv.mkDerivation rec {" n> "pname = \"" (p "" pkgn nil) "\";" n> "version = \"" p "\";" n n>
+            "src = fetchFromGitHub {" n> "owner = \"" (p "" own) "\";" n> "repo = \"" (s pkgn) "\";" n>
+            "rev = \"" "v${version}" "\";" n> "sha256 = \"" "${lib.fakeSha256}" "\";" n> "};" n n>
+            "nativeBuildInputs = [ " (p "makeWrapper") " ];" n n> "BuildInputs = [ " (p) " ];" n n>
+            "meta = with lib; {" n>
+            "homepage = \"" "https://github.com/" (s own) "/" (s pkgn) "\";" n>
+            "description = \"" (p) "\";" n>
+            "license = licenses." (p (completing-read "License: " '("agpl3" "asl20" "bsd1" "bsd2" "bsd3" "free" "gpl2" "gpl2Only" "gpl2Plus" "gpl3" "gpl3Only" "gpl3Plus" "isc" "lgpl21Only" "lgpl21Plus" "lgpl2Only" "lgpl2Plus" "lgpl3" "lgpl3Only" "mit" "mpl20" "ofl" "unfree"))) ";" n>
+            "maintainers = with maintainers; [ " (s own) " ];" n>
+            "platforms = platforms." 
+            (p (completing-read "Platform: " '("all" "allBut" "arm" "cygwin" "darwin" "freebsd" "gnu" "i686" "illumos" "linux" "mesaPlatforms" "mips" "netbsd" "none" "openbsd" "unix" "x86"))) ";" n> q "};" n> "}"
+)


### PR DESCRIPTION
Added snippet for nix-mode, which is used for packaging in nixpkgs repo.

Useful for creating new package.
This also gives options to choose license or platform. Any improvements are welcome!

I hope the elisp code i have used is minimal and enough for its purpose.
I tried adding this between buildinput (17th line) and meta (18th) `(tempel-insert 'installphase)` which is already a template in nix.eld, but it did not give me expected the result, it repeats that template more than twice.
Users can manually do it, so no need to bloat this template further.

Indentation works as expected.

Is there a way to make it (prompt) ask for options under platform and license later or when point reaches there?
What i mean is, when you invoke this template, it first runs `(p (completing-read "License: " ....` which is actually at the end of the file.

I'm still a novice in elisp, Any suggestions to improve this template is appreciated!