### PR TITLE
Add rust snippet for debug macro.

### DIFF
--- a/templates/rust.eld
+++ b/templates/rust.eld
@@ -13,3 +13,5 @@ rust-mode rust-ts-mode
 (crt "extern crate " q ";")
 
 (drv "#[derive(" p ")]" q)
+
+(d "dbg!(" p ")" q)


### PR DESCRIPTION
This adds a rust snippet for the [dbg!](https://doc.rust-lang.org/std/macro.dbg.html) macro.