### PR TITLE
Fix struct template from automatically autocomplete

### DIFF
--- a/templates/go.eld
+++ b/templates/go.eld
@@ -12,7 +12,7 @@ go-mode go-ts-mode
 (lf "log.Printf(\"\\n%#v\\n\", " q ")")
 (ln "log.Println(" q ")")
 
-(str "type " p " struct {" n> q n "}")
+(stt "type " p " struct {" n> q n "}")
 
 (inf "type " p " interface {" n> q n "}")
 


### PR DESCRIPTION
Every time I need to type `struct` cape automatically replace `str` into template content, which is super annoying.