### PR TITLE
Renamed JavaScript template file

### DIFF
--- a/templates/js-base.eld
+++ b/templates/js-base.eld
@@ -1,4 +1,4 @@
-js-mode js2-mode
+js-base-mode
 
 (if "if (" p ") {" n> q n> "}")
 (el "if (" p ") {" n> p n> "} else { " n> q n> "}")


### PR DESCRIPTION
The filename I originally used in #46 did not match the JavaScript mode name, as a result the templates were actually not loaded when needed. My apologies for the inconvenience.