### PR TITLE
Added "package-header" template for Emacs Lisp.

### DIFF
--- a/templates/emacs-lisp.eld
+++ b/templates/emacs-lisp.eld
@@ -31,3 +31,39 @@ emacs-lisp-mode
          ";;; " (file-name-nondirectory (or (buffer-file-name) (buffer-name))) " ends here" n)
 (log "(message \"LOG %s " (s sexp) ": %S"
      "\" (format-time-string \"%X\") " sexp ")")
+(package-header ";;; " (p (file-name-base (or (buffer-file-name) (buffer-name))) file) ".el --- " (p "summary" summary) " -*- lexical-binding: t -*-" n n
+
+                ";; Author: " (p (user-full-name)) n
+                ";; Version: " (p "version") n
+                ";; Package-Requires: " (p "dependencies") n
+                ";; Homepage: " (p "homepage") n
+                ";; Keywords: " (p "keywords") n n
+
+                ";; This file is not part of GNU Emacs" n n
+
+                (p (concat
+                    ";; This program is free software: you can redistribute it and/or modify\n" 
+                    ";; it under the terms of the GNU General Public License as published by\n"
+                    ";; the Free Software Foundation, either version 3 of the License, or\n"
+                    ";; (at your option) any later version.\n\n"
+
+                    ";; This program is distributed in the hope that it will be useful,\n"
+                    ";; but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+                    ";; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+                    ";; GNU General Public License for more details.\n\n"
+
+                    ";; You should have received a copy of the GNU General Public License\n"
+                    ";; along with this program.  If not, see <https://www.gnu.org/licenses/>."))
+
+                n n
+
+                ";;; Commentary:" n n
+                
+                ";; " (p "commentary") n n
+
+                ";;; Code:" n n
+
+                (p "(message \"Hello, World\")") n n
+
+                "(provide '" (s file) ")" n
+                ";;; " (s file) ".el ends here")


### PR DESCRIPTION
This is a long one, but this is a template I made heavy use of in YASnippets (since I use a modularized configuration for my Emacs), so I figured I'd port it over to tempel.