### PR TITLE
Fix org-mode templates

### DIFF
--- a/templates/org.eld
+++ b/templates/org.eld
@@ -1,35 +1,31 @@
 org-mode
 
 
-(ttl & "#+title: " p n "#+author: " p n "#+language: " p n n)
-(qt & "#+begin_quote" n> r> n> "#+end_quote")
-(exmpl & "#+begin_example" n> r> n> "#+end_example")
-(cntr & "#+begin_center" n> r> n> "#+end_center")
-(comm & "#+begin_comment" n> r> n> "#+end_comment")
+(ttl      & "#+title: " p n "#+author: " p n "#+language: " p n n)
+(bgn      & "#+begin_" (s name) n r n "#+end_" name)
+(exmpl    & "#+begin_example" n> r> n> "#+end_example")
+(cntr     & "#+begin_center" n> r> n> "#+end_center")
+(comm     & "#+begin_comment" n> r> n> "#+end_comment")
+(mrginnte & "#+begin_marginnote" n> r> n "#+end_marginnote")
+(qt       & "#+begin_quote" n> r> n> "#+end_quote")
+(sdnt     & "#+begin_sidenote" n> r> n "#+end_sidenote")
+(src      & "#+begin_src " p n r n "#+end_src"
+ :post (org-edit-src-code))
+(rst      & "#+begin_src restclient" p n r n "#+end_src"
+ :post (org-edit-src-code))
+(elsp     & "#+begin_src emacs-lisp" n r n "#+end_src"
+ :post (org-edit-src-code))
+(gnplt    & "#+begin_src gnuplot :var data=" (p "table") " :file " (p "plot.png") n r n "#+end_src"
+ :post (org-edit-src-code))
 (vrs & "#+begin_verse" n> r> n> "#+end_verse")
-(src & "#+begin_src " p n r n "#+end_src" :post (org-edit-src-code))
-(rst & "#+begin_src restclient" p n r n "#+end_src" :post (org-edit-src-code))
-(elsp & "#+begin_src emacs-lisp" n r n "#+end_src" :post (org-edit-src-code))
-(readonly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
-(oxhugo & ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: " (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
-(readmecollapse  "*** " (p "Heading") n "#+HTML: <details> <summary> " (p "sub-heading")  " </summary>" n (r> "link or any comments") n n "#+HTML: </details>" n)
+(rdnly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
+(oxhugo & ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: "
+ (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
+(rdmecollapse  "*** " (p "Heading") n "#+HTML: <details> <summary> " (p "sub-heading")  " </summary>" n
+ (r> "link or any comments") n n "#+HTML: </details>" n)
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
-(caption & "#+caption: ")
-(drawer & ":" p ":" n r ":end:")
-(begin & "#+begin_" (s name) n r n "#+end_" name)
-(quote & "#+begin_quote" n> r> n "#+end_quote")
-(sidenote & "#+begin_sidenote" n> r> n "#+end_sidenote")
-(marginnote & "#+begin_marginnote" n> r> n "#+end_marginnote")
-(example & "#+begin_example" n> r> n "#+end_example")
-(center & "#+begin_center" n> r> n "#+end_center")
-(ascii & "#+begin_export ascii" n> r> n "#+end_export")
-(html & "#+begin_export html" n> r> n "#+end_export")
-(latex & "#+begin_export latex" n> r> n "#+end_export")
-(comment & "#+begin_comment" n> r> n "#+end_comment")
-(verse & "#+begin_verse" n> r> n "#+end_verse")
-(gnuplot & "#+begin_src gnuplot :var data=" (p "table") " :file " (p "plot.png") n r n "#+end_src" :post (org-edit-src-code))
-(elisp & "#+begin_src emacs-lisp" n r n "#+end_src" :post (org-edit-src-code))
+(cptn & "#+caption: ")
+(drwr & ":" p ":" n r ":end:")
 (inlsrc "src_" p "{" q "}")
-(title & "#+title: " p n "#+author: " p n "#+language: " p n n)
 


### PR DESCRIPTION
There where some templates for org-mode with key as actual word. I need to remove them as they are automatically inserted every time I need to type actual word. This is very annoying, so I replace them with short keys. Also there were some duplicates too. 