### PR TITLE
fix: latex templates now work with auctex

### DIFF
--- a/tempel-collection.el
+++ b/tempel-collection.el
@@ -87,7 +87,7 @@
     (while (and mode (not (memq mode tempel-collection--loaded)))
       (push mode tempel-collection--loaded)
       (let ((file
-             (or (tempel-collection--mode-file (string-remove-suffix "-mode" (symbol-name mode)))
+             (or (tempel-collection--mode-file (downcase (string-remove-suffix "-mode" (symbol-name mode))))
                  (tempel-collection--mode-file (alist-get mode tempel-collection--aliases)))))
         (when file
           (setq tempel-collection--templates

--- a/templates/latex.eld
+++ b/templates/latex.eld
@@ -1,4 +1,4 @@
-latex-mode
+latex-mode LaTeX-mode
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
 (abstract "\\begin{abstract}\n" r> n> "\\end{abstract}")


### PR DESCRIPTION
Previously latex templates did not work with [AUCTeX](https://www.gnu.org/software/auctex/). Now they do.