### PR TITLE
feat: org babel python templates

### DIFF
--- a/templates/org.eld
+++ b/templates/org.eld
@@ -25,11 +25,11 @@ org-mode
  (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
 (rdmecollapse  "*** " (p "Heading") n "#+HTML: <details> <summary> " (p "sub-heading")  " </summary>" n
  (r> "link or any comments") n n "#+HTML: </details>" n)
-(python   & "#+begin_src python" n r n "#+end_src"
+(py_   & "#+begin_src python" n r n "#+end_src"
  :post (org-edit-src-code))
-(pythonvle & "#+begin_src python :results value" n r n "#+end_src"
+(py_vl & "#+begin_src python :results value" n r n "#+end_src"
  :post (org-edit-src-code))
-(pythonotpt & "#+begin_src python :results output" n r n "#+end_src"
+(py_otpt & "#+begin_src python :results output" n r n "#+end_src"
  :post (org-edit-src-code))
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format

--- a/templates/org.eld
+++ b/templates/org.eld
@@ -25,6 +25,12 @@ org-mode
  (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
 (rdmecollapse  "*** " (p "Heading") n "#+HTML: <details> <summary> " (p "sub-heading")  " </summary>" n
  (r> "link or any comments") n n "#+HTML: </details>" n)
+(python   & "#+begin_src python" n r n "#+end_src"
+ :post (org-edit-src-code))
+(pythonvle & "#+begin_src python :results value" n r n "#+end_src"
+ :post (org-edit-src-code))
+(pythonotpt & "#+begin_src python :results output" n r n "#+end_src"
+ :post (org-edit-src-code))
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
 (cptn & "#+caption: ")

--- a/templates/org.eld
+++ b/templates/org.eld
@@ -19,18 +19,18 @@ org-mode
  :post (org-edit-src-code))
 (gnplt    & "#+begin_src gnuplot :var data=" (p "table") " :file " (p "plot.png") n r n "#+end_src"
  :post (org-edit-src-code))
-(vrs & "#+begin_verse" n> r> n> "#+end_verse")
-(rdnly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
-(oxhugo & ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: "
- (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
-(rdmecollapse  "*** " (p "Heading") n "#+HTML: <details> <summary> " (p "sub-heading")  " </summary>" n
- (r> "link or any comments") n n "#+HTML: </details>" n)
 (py_   & "#+begin_src python" n r n "#+end_src"
  :post (org-edit-src-code))
 (py_vl & "#+begin_src python :results value" n r n "#+end_src"
  :post (org-edit-src-code))
 (py_otpt & "#+begin_src python :results output" n r n "#+end_src"
  :post (org-edit-src-code))
+(vrs & "#+begin_verse" n> r> n> "#+end_verse")
+(rdnly ":tangle yes :tangle-mode (identity #o444) :mkdirp yes" n)
+(oxhugo & ":PROPERTIES:"  n ":EXPORT_FILE_NAME: " (p "Simple Filename") n ":EXPORT_DATE: "
+ (format-time-string "%Y-%m-%d") n ":EXPORT_HUGO_DRAFT: false" n ":END:")
+(rdmecollapse  "*** " (p "Heading") n "#+HTML: <details> <summary> " (p "sub-heading")  " </summary>" n
+ (r> "link or any comments") n n "#+HTML: </details>" n)
 
 ;; taken from https://github.com/minad/tempel/blob/5b09f612cfd805dba5e90bf06580583cab045499/README.org#template-file-format
 (cptn & "#+caption: ")


### PR DESCRIPTION
Some org babel python templates:
1. `python` is a simple python source block.
2. `pythonvle` has `value` as a `:results` variable.
3. `pythonotpt` has `output` as a `:results` variable.