### PR TITLE
share js and ts base mode templates

### DIFF
--- a/templates/js-and-typescript-ts-base.eld
+++ b/templates/js-and-typescript-ts-base.eld
@@ -1,4 +1,4 @@
-js-base-mode
+js-base-mode typescript-ts-base-mode
 
 (if "if (" p ") {" n> q n "}" >)
 (el "if (" p ") {" n> p n "} else { " > n> q n "}" >)


### PR DESCRIPTION
not sure if there's a better way to represent this, but at a high level i think it makes sense to provide the same templates that are available to `js-base-mode` to `typescript-js-base-mode`. both are available in Emacs core, and they both inherit from `prog-mode` and otherwise have no other shared parent mode. curious about your thoughts here