### PR TITLE
Fix file associated with typescript modes.

### DIFF
--- a/tempel-collection.el
+++ b/tempel-collection.el
@@ -67,10 +67,10 @@
     (go-mod-ts-mode . "go-mod")
     (java-ts-mode . "java")
     (js-base-mode . "js")
+    (typescript-ts-base-mode . "js")
     (json-ts-mode . "json")
     (rust-ts-mode . "rust")
     (toml-ts-mode . "toml")
-    (typescript-ts-base-mode . "typescript")
     (yaml-ts-mode . "yaml")))
 
 (defun tempel-collection--mode-file (mode-name)


### PR DESCRIPTION
All typescript and javascript related mode should use the same file, allowing to share templates where no specific TS typing are used. For templates specific to JS or TS, a new section dedicated to the specific mode could be added in the same file.

Fixes #63 